### PR TITLE
Corrected case on includeSubDomains

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function hsts(options) {
   var maxAge = Math.round(maxAgeMS / 1000);
   var header = 'max-age=' + maxAge;
   if (options.includeSubdomains) {
-    header += '; includeSubdomains';
+    header += '; includeSubDomains';
   }
   if (options.preload) {
     header += '; preload';

--- a/test/index.js
+++ b/test/index.js
@@ -51,14 +51,14 @@ describe('hsts', function () {
     handler = hsts({ includeSubdomains: true });
     req.secure = true;
     handler(req, res, next);
-    assert(res.setHeader.calledWith('Strict-Transport-Security', 'max-age=86400; includeSubdomains'));
+    assert(res.setHeader.calledWith('Strict-Transport-Security', 'max-age=86400; includeSubDomains'));
   });
 
   it('can include subdomains and preload with no specified max-age', function () {
     handler = hsts({ includeSubdomains: true, preload: true });
     req.secure = true;
     handler(req, res, next);
-    assert(res.setHeader.calledWith('Strict-Transport-Security', 'max-age=86400; includeSubdomains; preload'));
+    assert(res.setHeader.calledWith('Strict-Transport-Security', 'max-age=86400; includeSubDomains; preload'));
   });
 
   it('is unset if req.secure is false', function () {
@@ -109,7 +109,7 @@ describe('hsts', function () {
   });
 
   it('can include subdomains', function () {
-    var expectedHeader = defaultHeader + '; includeSubdomains';
+    var expectedHeader = defaultHeader + '; includeSubDomains';
     req.secure = true;
     handler = hsts({ maxAge: maxAge, includeSubdomains: true });
     handler(req, res, next);


### PR DESCRIPTION
This is to correctly match rfc 6797 section 6.1.2

Which states:

6.1.2.  The includeSubDomains Directive

   The OPTIONAL "includeSubDomains" directive is a valueless directive
   which, if present (i.e., it is "asserted"), signals the UA that the
   HSTS Policy applies to this HSTS Host as well as any subdomains of
   the host's domain name.