### PR TITLE
hsts@2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This'll be set if `req.secure` is true, a boolean auto-populated by Express. If 
 app.use(hsts({
   maxAge: 1234000,
   setIf: function(req, res) {
-    return Math.random() < 0.5;
+    return req.secure || (req.headers['x-forwarded-proto'] === 'https')
   }
 }))
 

--- a/README.md
+++ b/README.md
@@ -7,22 +7,25 @@ HTTP Strict Transport Security middlware
 
 This middleware adds the `Strict-Transport-Security` header to the response. This tells browsers, "hey, only use HTTPS for the next period of time". ([See the spec](http://tools.ietf.org/html/rfc6797) for more.)
 
-This will set the Strict Transport Security header, telling browsers to visit by HTTPS for the next ninety days:
+This will set the Strict Transport Security header, telling browsers to visit by HTTPS for the next 180 days:
 
 ```javascript
 var hsts = require('hsts')
 
-var ninetyDaysInSeconds = 7776000
-
-app.use(hsts({ maxAge: ninetyDaysInSeconds }))
+app.use(hsts({
+  maxAge: 15552000  // 180 days in seconds
+}))
+// Strict-Transport-Security: max-age: 15552000; includeSubDomains
 ```
 
-You can also include subdomains. If this is set on *example.com*, supported browsers will also use HTTPS on *my-subdomain.example.com*. Here's how you do that:
+Note that the max age must be in seconds. *This was different in previous versions of this module!*
+
+The `includeSubDomains` directive is present by default. If this header is set on *example.com*, supported browsers will also use HTTPS on *my-subdomain.example.com*. You can disable this:
 
 ```javascript
 app.use(hsts({
-  maxAge: 10886400,       // 18 weeks in seconds
-  includeSubDomains: true
+  maxAge: 15552000,
+  includeSubDomains: false
 }))
 ```
 
@@ -36,13 +39,13 @@ app.use(hsts({
 }))
 ```
 
-This'll be set if `req.secure` is true, a boolean auto-populated by Express. If you're not using Express, that value won't necessarily be set, so you have two options:
+This header will be set `req.secure` is true, a boolean auto-populated by Express. If you're not using Express, that value won't necessarily be set, so you have two options:
 
 ```javascript
-// Set the header based on conditions
+// Set the header based on a condition
 app.use(hsts({
   maxAge: 1234000,
-  setIf: function(req, res) {
+  setIf: function (req, res) {
     return req.secure || (req.headers['x-forwarded-proto'] === 'https')
   }
 }))
@@ -53,7 +56,5 @@ app.use(hsts({
   force: true
 }))
 ```
-
-Note that the max age must be in seconds.
 
 This only works if your site actually has HTTPS. It won't tell users on HTTP to *switch* to HTTPS, it will just tell HTTPS users to stick around. You can enforce this with the [express-enforces-ssl](https://github.com/aredo/express-enforces-ssl) module. This header is [somewhat well-supported by browsers](http://caniuse.com/#feat=stricttransportsecurity).

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 var util = require('core-util-is')
 
-var oneDayInSeconds = 86400
+var defaultMaxAge = 180 * 24 * 60 * 60
 
 module.exports = function hsts (options) {
   options = options || {}
 
-  var maxAge = options.maxAge != null ? options.maxAge : oneDayInSeconds
+  var maxAge = options.maxAge != null ? options.maxAge : defaultMaxAge
   var includeSubDomains = (options.includeSubDomains !== false) && (options.includeSubdomains !== false)
   var force = options.force
   var setIf = options.setIf

--- a/index.js
+++ b/index.js
@@ -6,34 +6,36 @@ module.exports = function hsts (options) {
   options = options || {}
 
   var maxAge = options.maxAge != null ? options.maxAge : oneDayInSeconds
+  var includeSubDomains = (options.includeSubDomains !== false) && (options.includeSubdomains !== false)
   var force = options.force
   var setIf = options.setIf
 
-  if (options.maxage != null) {
-    throw new Error('Did you mean to pass "maxAge" instead of "maxage"?')
-  }
-  if (!util.isObject(options)) {
-    throw new Error('HSTS must be passed an object or undefined.')
+  if (options.hasOwnProperty('maxage')) {
+    throw new Error('maxage is not a supported property. Did you mean to pass "maxAge" instead of "maxage"?')
   }
   if (arguments.length > 1) {
     throw new Error('HSTS passed the wrong number of arguments.')
   }
-
   if (!util.isNumber(maxAge)) {
     throw new TypeError('HSTS must be passed a numeric maxAge parameter.')
   }
   if (maxAge < 0) {
     throw new RangeError('HSTS maxAge must be nonnegative.')
   }
-  if (setIf && !util.isFunction(setIf)) {
-    throw new TypeError('setIf must be a function.')
+  if (options.hasOwnProperty('setIf')) {
+    if (!util.isFunction(setIf)) {
+      throw new TypeError('setIf must be a function.')
+    }
+    if (options.hasOwnProperty('force')) {
+      throw new Error('setIf and force cannot both be specified.')
+    }
   }
-  if (setIf && force) {
-    throw new Error('setIf and force cannot both be specified.')
+  if (options.hasOwnProperty('includeSubDomains') && options.hasOwnProperty('includeSubdomains')) {
+    throw new Error('includeSubDomains and includeSubdomains cannot both be specified.')
   }
 
-  var header = 'max-age=' + maxAge
-  if (options.includeSubDomains || options.includeSubdomains) {
+  var header = 'max-age=' + Math.round(maxAge)
+  if (includeSubDomains) {
     header += '; includeSubDomains'
   }
   if (options.preload) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "bugs": "https://github.com/helmetjs/hsts/issues",
   "scripts": {
-    "test": "standard && mocha"
+    "pretest": "standard",
+    "test": "mocha"
   },
   "devDependencies": {
     "mocha": "^2.3.4",

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
-// These tests, unlike others, require mocking of requests and responses.
-// Because this header should only be set for HTTPS and that's hard to
-// reliably determine, heuristics are used.
+// Unlike other tests, these require us to mock requests and responses.
+// Because this header should only be set for HTTPS, which is hard to fake
+// reliably, we call the middleware function directly, with fake request and
+// response objects.
 
 var hsts = require('..')
 
@@ -8,116 +9,159 @@ var assert = require('assert')
 var sinon = require('sinon')
 
 describe('hsts', function () {
-  var maxAge = 7776000  // 90 days in seconds
-  var defaultHeader = 'max-age=' + maxAge
-
-  var handler, req, res, next
   beforeEach(function () {
-    handler = hsts({ maxAge: maxAge })
-    req = {}
-    res = { setHeader: sinon.spy() }
-    next = sinon.spy()
+    this.req = { secure: true }
+    this.res = { setHeader: sinon.spy() }
+    this.next = sinon.spy()
   })
 
   it('throws an error with invalid parameters', function () {
-    assert.throws(hsts.bind(this, '1234'))
-    assert.throws(hsts.bind(this, -1234))
-    assert.throws(hsts.bind(this, 1234))
-    assert.throws(hsts.bind(this, 1234, true))
     assert.throws(hsts.bind(this, { maxAge: -123 }))
     assert.throws(hsts.bind(this, { maxAge: '123' }))
     assert.throws(hsts.bind(this, { maxAge: true }))
+    assert.throws(hsts.bind(this, { maxAge: {} }))
+    assert.throws(hsts.bind(this, { maxAge: [] }))
+
+    assert.throws(hsts.bind(this, { maxAge: 1234 }, 'extra argument'))
+
     assert.throws(hsts.bind(this, { setIf: 123 }))
     assert.throws(hsts.bind(this, { setIf: true }))
-    assert.throws(hsts.bind(this, { setIf: function () {}, force: true }))
+
+    assert.throws(hsts.bind(this, { maxage: false }))
     assert.throws(hsts.bind(this, { maxage: 1234 }))
+    assert.throws(hsts.bind(this, {
+      includeSubDomains: true,
+      includeSubdomains: true
+    }))
+    assert.throws(hsts.bind(this, {
+      includeSubDomains: false,
+      includeSubdomains: true
+    }))
+    assert.throws(hsts.bind(this, { setIf: function () {}, force: true }))
   })
 
-  it('sets a default value to 1 day', function () {
-    handler = hsts()
-    req.secure = true
-    handler(req, res, next)
-    assert(res.setHeader.calledWith('Strict-Transport-Security', 'max-age=86400'))
+  it('sets no header if req.secure is false', function () {
+    this.req.secure = false
+
+    hsts()(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(!this.res.setHeader.called)
   })
 
-  it('can include subdomains with no specified max-age', function () {
-    handler = hsts({ includeSubdomains: true })
-    req.secure = true
-    handler(req, res, next)
-    assert(res.setHeader.calledWith('Strict-Transport-Security', 'max-age=86400; includeSubDomains'))
+  it('by default, sets max-age to 1 day and includeSubDomains', function () {
+    hsts()(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400; includeSubDomains'))
   })
 
-  it('can include subdomains and preload with no specified max-age', function () {
-    handler = hsts({ includeSubdomains: true, preload: true })
-    req.secure = true
-    handler(req, res, next)
-    assert(res.setHeader.calledWith('Strict-Transport-Security', 'max-age=86400; includeSubDomains; preload'))
+  it('can set max-age to a positive integer', function () {
+    hsts({
+      maxAge: 1234
+    })(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=1234; includeSubDomains'))
   })
 
-  it('is unset if req.secure is false', function () {
-    req.secure = false
-    handler(req, res, next)
-    assert(!res.setHeader.called)
+  it('rounds the max-age', function () {
+    hsts({
+      maxAge: 1234.56
+    })(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=1235; includeSubDomains'))
   })
 
-  it('is set if req.secure is true', function () {
-    req.secure = true
-    handler(req, res, next)
-    assert(res.setHeader.calledWith('Strict-Transport-Security', defaultHeader))
+  it('can set max-age to -0', function () {
+    hsts({
+      maxAge: -0
+    })(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=0; includeSubDomains'))
   })
 
-  it('is always set if forced', function () {
-    handler = hsts({ maxAge: maxAge, force: true })
-    req.secure = false
-    handler(req, res, next)
-    assert(res.setHeader.calledWith('Strict-Transport-Security', defaultHeader))
+  it('can set max-age to 0', function () {
+    hsts({
+      maxAge: 0
+    })(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=0; includeSubDomains'))
   })
 
-  it('can be set to -0', function () {
-    req.secure = true
-    handler = hsts({ maxAge: -0 })
-    handler(req, res, next)
-    assert(res.setHeader.calledWith('Strict-Transport-Security', 'max-age=0'))
+  it('can disable subdomains with the includeSubDomains option', function () {
+    hsts({
+      includeSubDomains: false
+    })(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400'))
   })
 
-  it('can be set to 0', function () {
-    req.secure = true
-    handler = hsts({ maxAge: 0 })
-    handler(req, res, next)
-    assert(res.setHeader.calledWith('Strict-Transport-Security', 'max-age=0'))
+  it('can disable subdomains with the includeSubdomains option', function () {
+    hsts({
+      includeSubdomains: false
+    })(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400'))
   })
 
-  it('can include subdomains using includeSubdomains option', function () {
-    var expectedHeader = defaultHeader + '; includeSubDomains'
-    req.secure = true
-    handler = hsts({ maxAge: maxAge, includeSubdomains: true })
-    handler(req, res, next)
-    assert(res.setHeader.calledWith('Strict-Transport-Security', expectedHeader))
+  it('can enable preloading', function () {
+    hsts({
+      preload: true
+    })(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400; includeSubDomains; preload'))
   })
 
-  it('can include subdomains using preferred includeSubDomains option', function () {
-    var expectedHeader = defaultHeader + '; includeSubDomains'
-    req.secure = true
-    handler = hsts({ maxAge: maxAge, includeSubdomains: false, includeSubDomains: true })
-    handler(req, res, next)
-    assert(res.setHeader.calledWith('Strict-Transport-Security', expectedHeader))
-  })
-
-  it('lets you decide whether it should be set', function () {
-    handler = hsts({
-      maxAge: maxAge,
+  it('can set the header based on your own condition', function () {
+    var options = {
       setIf: function (req) {
         return req.pleaseSet
       }
-    })
-    handler(req, res, next)
-    req.pleaseSet = true
-    handler(req, res, next)
-    assert(res.setHeader.calledOnce)
+    }
+
+    hsts(options)({}, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(!this.res.setHeader.called)
+
+    hsts(options)({ pleaseSet: true }, this.res, this.next)
+
+    assert(this.next.calledTwice)
+    assert(this.next.alwaysCalledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400; includeSubDomains'))
+  })
+
+  it('can force the header', function () {
+    this.req.secure = false
+
+    hsts({
+      force: true
+    })(this.req, this.res, this.next)
+
+    assert(this.next.calledOnce)
+    assert(this.next.calledWithExactly())
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400; includeSubDomains'))
   })
 
   it('names its function and middleware', function () {
     assert.equal(hsts.name, 'hsts')
-    assert.equal(hsts({ maxAge: 1 }).name, 'hsts')
+    assert.equal(hsts().name, 'hsts')
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -50,12 +50,14 @@ describe('hsts', function () {
     assert(!this.res.setHeader.called)
   })
 
-  it('by default, sets max-age to 1 day and includeSubDomains', function () {
+  it('by default, sets max-age to 180 days and adds "includeSubDomains"', function () {
     hsts()(this.req, this.res, this.next)
 
     assert(this.next.calledOnce)
     assert(this.next.calledWithExactly())
-    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400; includeSubDomains'))
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=15552000; includeSubDomains'))
+
+    assert.equal(15552000, 180 * 24 * 60 * 60)
   })
 
   it('can set max-age to a positive integer', function () {
@@ -105,7 +107,7 @@ describe('hsts', function () {
 
     assert(this.next.calledOnce)
     assert(this.next.calledWithExactly())
-    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400'))
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=15552000'))
   })
 
   it('can disable subdomains with the includeSubdomains option', function () {
@@ -115,7 +117,7 @@ describe('hsts', function () {
 
     assert(this.next.calledOnce)
     assert(this.next.calledWithExactly())
-    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400'))
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=15552000'))
   })
 
   it('can enable preloading', function () {
@@ -125,7 +127,7 @@ describe('hsts', function () {
 
     assert(this.next.calledOnce)
     assert(this.next.calledWithExactly())
-    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400; includeSubDomains; preload'))
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=15552000; includeSubDomains; preload'))
   })
 
   it('can set the header based on your own condition', function () {
@@ -145,7 +147,7 @@ describe('hsts', function () {
 
     assert(this.next.calledTwice)
     assert(this.next.alwaysCalledWithExactly())
-    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400; includeSubDomains'))
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=15552000; includeSubDomains'))
   })
 
   it('can force the header', function () {
@@ -157,7 +159,7 @@ describe('hsts', function () {
 
     assert(this.next.calledOnce)
     assert(this.next.calledWithExactly())
-    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=86400; includeSubDomains'))
+    assert(this.res.setHeader.calledWithExactly('Strict-Transport-Security', 'max-age=15552000; includeSubDomains'))
   })
 
   it('names its function and middleware', function () {


### PR DESCRIPTION
**Seems ready to be merged and released!**

Take a look at this PR to see everything going into version 2 of this module.

See the [2.0](https://github.com/helmetjs/hsts/milestone/1) milestone for more details.

Breaking changes:

- `maxAge` option is now in _seconds_, not milliseconds
- `maxAge` now defaults to 180 days (instead of 1 day)
- `includeSubDomains` is true by default
- minor breaking changes:
  - Some options are now error-checked for their presence, rather than their truthyness. For example, `maxage: false` didn't used to throw an error, but now it does
  - `includeSubdomains` and `includeSubDomains` cannot both be included

Closes #5.
Closes #10.
Closes #12.