### PR TITLE
Require options.preload to equal boolean true

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ module.exports = function hsts (options) {
     header += '; includeSubDomains'
   }
   if (options.preload) {
-    header += '; preload'
+    if (options.preload === true) {
+      header += '; preload'
+    }
   }
 
   return function hsts (req, res, next) {


### PR DESCRIPTION
Right now, if options.preload was set to 'false', it would be set.

Might want stricter validation on the option