### PR TITLE
Add typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+import { Request, Response, Handler } from 'express';
+
+export interface HstsOptions {
+    maxAge?: number;
+    includeSubDomains?: boolean;
+    preload?: boolean;
+    setIf?: (req: Request, res: Response) => boolean;
+}
+
+export function hsts(options?: HstsOptions): Handler;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var defaultMaxAge = 180 * 24 * 60 * 60
 
-module.exports = function hsts (options) {
+function hsts (options) {
   options = options || {}
 
   var maxAge = options.maxAge != null ? options.maxAge : defaultMaxAge
@@ -42,6 +42,9 @@ module.exports = function hsts (options) {
     next()
   }
 }
+
+module.exports = hsts;
+module.exports.hsts = hsts;
 
 function alwaysTrue () {
   return true

--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
       "beforeEach",
       "it"
     ]
-  }
+  },
+  "typings": "index.d.ts"
 }


### PR DESCRIPTION
Hi,

here's typings for the module for typescript users.
I also added the `module.exports.hsts` named export, since using it is more obvious than the commonjs default export when using es6 syntax.